### PR TITLE
Simplify import of pinned packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
 # MakerDAO Nix Packages
 
-Then put the following in your `default.nix`:
+Put the following at the top of your `default.nix`:
 
 ```
-{ pkgs ? import (fetchGit {
-    url = "https://github.com/makerdao/nixpkgs-pin";
-    ref = "master";
-  }) {}
+{ pkgs ? import (fetchGit "https://github.com/makerdao/nixpkgs-pin") {}
 }:
 ```
 
-To freeze at a certain revision of this repo set `rev` to the commit hash you
-wish to pin:
+**Recommended**: Pin a package set at a certain revision by specifying `rev`
+with the commit hash you wish to pin it at:
 
 ```
 { pkgs ? import (fetchGit {
     url = "https://github.com/makerdao/nixpkgs-pin";
-    ref = "master";
     rev = "aa8cea6eef397cb3c551b9e41f54f8f9f230fd9b";
   }) {}
 }:
 ```
 
+You can also specify `ref` to point to a GIT branch or tag in combination with
+or without `rev`.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # MakerDAO Nix Packages
 
-Create a `pkgs.nix` file with and update `rev` to a relevant commit hash:
+Then put the following in your `default.nix`:
 
 ```
-import (fetchGit {
-  url = "https://github.com/makerdao/nixpkgs-pin";
-  rev = "d4b7fe56b38236566b3014d328be1bd9c7be7a2f";
-  ref = "master";
-})
+{ pkgs ? import (fetchGit {
+    url = "https://github.com/makerdao/nixpkgs-pin";
+    ref = "master";
+  }) {}
+}:
 ```
 
-Then put the following in your `default.nix` to be able to inject and override
-`nixpkgs` source:
+To freeze at a certain revision of this repo set `rev` to the commit hash you
+wish to pin:
 
 ```
-{ pkgsSrc ? (import ./pkgs.nix {}).pkgsSrc
-, pkgs ? (import ./pkgs.nix { inherit pkgsSrc; }).pkgs
-}: with pkgs;
+{ pkgs ? import (fetchGit {
+    url = "https://github.com/makerdao/nixpkgs-pin";
+    ref = "master";
+    rev = "aa8cea6eef397cb3c551b9e41f54f8f9f230fd9b";
+  }) {}
+}:
 ```
+

--- a/dapptools-overlay.nix
+++ b/dapptools-overlay.nix
@@ -14,10 +14,7 @@ in
   rec {
     current = latest;
 
-    latest = fetchDapptoolsVersion {
-      rev = "72f23c671495e48e2a9558b753c111121fa2c2a8";
-      sha256 = "1h9wllbgnwyrpqyvij70zgk0n9d1gg5qy46l5bgpf4b58092547d";
-    };
+    latest = seth-0_8_4;
 
     dapp-0_16_0 = fetchDapptoolsVersion {
       rev = "6943c76bfb8e0b1fce54c3d9bba6f0f7e50d2f5c";
@@ -47,5 +44,10 @@ in
     dapp-0_26_0 = fetchDapptoolsVersion {
       rev = "eb2380c990179ada97fc1ee376ad6f2a32bfe833";
       sha256 = "0x3pf08qnxdlsfcv5wj62dhkfq24ngi0g4q5g7dy8c422k1mvmf9";
+    };
+
+    seth-0_8_4 = fetchDapptoolsVersion {
+      rev = "72f23c671495e48e2a9558b753c111121fa2c2a8";
+      sha256 = "1h9wllbgnwyrpqyvij70zgk0n9d1gg5qy46l5bgpf4b58092547d";
     };
   } // dapptoolsOverrides

--- a/dapptools-overlay.nix
+++ b/dapptools-overlay.nix
@@ -11,7 +11,7 @@ let
     fetchSubmodules = true;
   };
 in rec {
-  current = seth-0_8_4;
+  default = seth-0_8_4;
   latest = seth-0_8_4;
 
   seth-0_8_4 = fetchDapptoolsVersion {

--- a/dapptools-overlay.nix
+++ b/dapptools-overlay.nix
@@ -10,44 +10,42 @@ let
     url = "https://github.com/dapphub/dapptools";
     fetchSubmodules = true;
   };
-in
-  rec {
-    current = latest;
+in rec {
+  current = seth-0_8_4;
+  latest = seth-0_8_4;
 
-    latest = seth-0_8_4;
+  seth-0_8_4 = fetchDapptoolsVersion {
+    rev = "72f23c671495e48e2a9558b753c111121fa2c2a8";
+    sha256 = "1h9wllbgnwyrpqyvij70zgk0n9d1gg5qy46l5bgpf4b58092547d";
+  };
 
-    dapp-0_16_0 = fetchDapptoolsVersion {
-      rev = "6943c76bfb8e0b1fce54c3d9bba6f0f7e50d2f5c";
-      sha256 = "0w2fhwh4r6lzgvdav2vdm4wglydc7i6h461zfn91dh09sqjpzzfw";
-    };
+  dapp-0_26_0 = fetchDapptoolsVersion {
+    rev = "eb2380c990179ada97fc1ee376ad6f2a32bfe833";
+    sha256 = "0x3pf08qnxdlsfcv5wj62dhkfq24ngi0g4q5g7dy8c422k1mvmf9";
+  };
 
-    dapp-0_18_0 = fetchDapptoolsVersion {
-      rev = "deb8b07972a28c4753c82215ed0c0c5b94cb8e31";
-      sha256 = "11l5rchvs7zbi02wjkfd5i25bv5ypjjh1bcdq3q2xb337ismgncb";
-    };
+  hevm-0_28 = fetchDapptoolsVersion {
+    rev = "214632b08a39872d50ceb3a726b0ca2d70d19e06";
+    sha256 = "1qa3rrk51pjm2r8jnz294mj6x5qaxwzz6lzznnzy0782q5s1m5pr";
+  };
 
-    dapp-0_18_1 = fetchDapptoolsVersion {
-      rev = "7207c0a92f0aaa19b60c84c14c1ed078892b0436";
-      sha256 = "05vryrd8377bi3k8igvhzhjcbp7sq5jsmn75nm71z41yyvlhmrj2";
-    };
+  dapp-0_19_0 = fetchDapptoolsVersion {
+    rev = "10388fb8083e9b3aff53a48afb65c746ade7093b";
+    sha256 = "0hynnfgvyjwhzxkpbfnwvazvgcvgvb20rar56cji2ybig0kfaz7f";
+  };
 
-    dapp-0_19_0 = fetchDapptoolsVersion {
-      rev = "10388fb8083e9b3aff53a48afb65c746ade7093b";
-      sha256 = "0hynnfgvyjwhzxkpbfnwvazvgcvgvb20rar56cji2ybig0kfaz7f";
-    };
+  dapp-0_18_1 = fetchDapptoolsVersion {
+    rev = "7207c0a92f0aaa19b60c84c14c1ed078892b0436";
+    sha256 = "05vryrd8377bi3k8igvhzhjcbp7sq5jsmn75nm71z41yyvlhmrj2";
+  };
 
-    hevm-0_28 = fetchDapptoolsVersion {
-      rev = "214632b08a39872d50ceb3a726b0ca2d70d19e06";
-      sha256 = "1qa3rrk51pjm2r8jnz294mj6x5qaxwzz6lzznnzy0782q5s1m5pr";
-    };
+  dapp-0_18_0 = fetchDapptoolsVersion {
+    rev = "deb8b07972a28c4753c82215ed0c0c5b94cb8e31";
+    sha256 = "11l5rchvs7zbi02wjkfd5i25bv5ypjjh1bcdq3q2xb337ismgncb";
+  };
 
-    dapp-0_26_0 = fetchDapptoolsVersion {
-      rev = "eb2380c990179ada97fc1ee376ad6f2a32bfe833";
-      sha256 = "0x3pf08qnxdlsfcv5wj62dhkfq24ngi0g4q5g7dy8c422k1mvmf9";
-    };
-
-    seth-0_8_4 = fetchDapptoolsVersion {
-      rev = "72f23c671495e48e2a9558b753c111121fa2c2a8";
-      sha256 = "1h9wllbgnwyrpqyvij70zgk0n9d1gg5qy46l5bgpf4b58092547d";
-    };
-  } // dapptoolsOverrides
+  dapp-0_16_0 = fetchDapptoolsVersion {
+    rev = "6943c76bfb8e0b1fce54c3d9bba6f0f7e50d2f5c";
+    sha256 = "0w2fhwh4r6lzgvdav2vdm4wglydc7i6h461zfn91dh09sqjpzzfw";
+  };
+} // dapptoolsOverrides

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,6 @@ let srcs = import ./srcs.nix; in
 
 import pkgs.path {
   overlays = [
-    (import ./maker-overlay.nix { inherit dapptoolsOverrides; })
+    (import ./overlay.nix { inherit dapptoolsOverrides; })
   ];
 }

--- a/default.nix
+++ b/default.nix
@@ -1,34 +1,11 @@
-{
-  pkgsSrc ? fetchTarball {
-    name = "nixpkgs-19.03";
-    # pin the current release-18.09 commit taken from dapptools
-    url = "https://github.com/nixos/nixpkgs/archive/f1707d8875276cfa110139435a7e8998b4c2a4fd.tar.gz";
-    sha256 = "14p7qvn3z58asx5naa2l5hvp1fddi186h385f7cj2ciw4pknrj9m";
-  },
-  dapptoolsOverrides ? {}
+let srcs = import ./srcs.nix; in
+
+{ pkgs ? import srcs.nixpkgs {}
+, dapptoolsOverrides ? {}
 }:
 
-let
-  inherit (builtins) map listToAttrs attrNames;
-  mapAttrs = if (builtins ? mapAttrs)
-    then builtins.mapAttrs
-    else f: attrs:
-      listToAttrs (map
-        (name: { inherit name; value = f name attrs."${name}"; })
-        (attrNames attrs));
-in rec {
-  inherit pkgsSrc;
-
-  mkPkgs = { extraOverlays ? [] }: dappPkgsSrc:
-    import pkgsSrc {
-      overlays = [
-        (import "${dappPkgsSrc}/overlay.nix")
-        (import ./maker-overlay.nix)
-      ] ++ extraOverlays;
-    };
-
-  dapptoolsVersions = (import pkgsSrc {}).callPackage ./dapptools-overlay.nix { inherit dapptoolsOverrides; };
-  pkgsVersions = mapAttrs (_: mkPkgs {}) dapptoolsVersions;
-
-  pkgs = pkgsVersions.current;
+import pkgs.path {
+  overlays = [
+    (import ./maker-overlay.nix { inherit dapptoolsOverrides; })
+  ];
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -22,7 +22,8 @@ in rec {
   # Inherit derivations from dapptools
   inherit (dappPkgs)
     dapp ethsign seth solc hevm solc-versions go-ethereum-unlimited evmdis
-    mcd dai setzer
+    mcd dai setzer dapp2
+    solidityPackage
     ;
 
   setzer-mcd = self.callPackage srcs.setzer-mcd {};

--- a/overlay.nix
+++ b/overlay.nix
@@ -22,6 +22,8 @@ in rec {
     mcd dai setzer
     ;
 
+  setzer-mcd = self.callPackage srcs.setzer-mcd {};
+
   sethret = (import srcs.sethret { inherit pkgs; }).sethret;
 
   dapp2nix = import srcs.dapp2nix { inherit pkgs; };

--- a/overlay.nix
+++ b/overlay.nix
@@ -16,10 +16,11 @@ in rec {
 
   dappPkgs = dappPkgsVersions.current;
 
-  inherit (dappPkgs) dapp ethsign seth solc;
-
-  # Add mcd-cli and sethret to local scope
-  mcd-cli = callPackage srcs.mcd-cli {};
+  # Inherit derivations from dapptools
+  inherit (dappPkgs)
+    dapp ethsign seth solc hevm solc-versions go-ethereum-unlimited evmdis
+    mcd dai setzer
+    ;
 
   sethret = (import srcs.sethret { inherit pkgs; }).sethret;
 
@@ -31,7 +32,7 @@ in rec {
     coreutils gnugrep gnused findutils
     bc jq
     solc
-    dapp ethsign seth mcd-cli
+    dapp ethsign seth mcd
   ];
 
   makerScriptPackage = self.callPackage ./script-builder.nix {};

--- a/overlay.nix
+++ b/overlay.nix
@@ -14,7 +14,10 @@ in rec {
     (_: dappPkgsSrc: import dappPkgsSrc {})
     dapptoolsVersions;
 
-  dappPkgs = dappPkgsVersions.current;
+  dappPkgs = if dappPkgsVersions ? current
+    then dappPkgsVersions.current
+    else dappPkgsVersions.default
+    ;
 
   # Inherit derivations from dapptools
   inherit (dappPkgs)

--- a/srcs.nix
+++ b/srcs.nix
@@ -5,6 +5,12 @@
     rev = "ea553d8c67c6a718448da50826ff5b6916dc9c59";
   };
 
+  setzer-mcd = fetchGit {
+    url = "https://github.com/makerdao/setzer-mcd";
+    ref = "master";
+    rev = "c528da640393a3d79ef314a7f86ae363d503a240";
+  };
+
   sethret = fetchGit {
     url = https://github.com/icetan/sethret.git;
     rev = "ef77915e2881011603491275f36b44bf2478b408";

--- a/srcs.nix
+++ b/srcs.nix
@@ -1,14 +1,14 @@
 {
   nixpkgs = fetchGit {
     url = "https://github.com/nixos/nixpkgs-channels";
-    ref = "nixos-19.09";
     rev = "ea553d8c67c6a718448da50826ff5b6916dc9c59";
+    ref = "nixos-19.09";
   };
 
   setzer-mcd = fetchGit {
     url = "https://github.com/makerdao/setzer-mcd";
+    rev = "ba3cc5768d4d289ea3ddea3c9b3b77d8e931ea4b";
     ref = "master";
-    rev = "c528da640393a3d79ef314a7f86ae363d503a240";
   };
 
   sethret = fetchGit {
@@ -18,8 +18,8 @@
 
   dapp2nix = fetchGit {
     url = "https://github.com/icetan/dapp2nix";
-    ref = "v2.1.7";
     rev = "5d433e6d5d8b89da808a51a3c8a0559893efbaf5";
+    ref = "v2.1.7";
   };
 
   abi-to-dhall = fetchGit {

--- a/srcs.nix
+++ b/srcs.nix
@@ -1,0 +1,29 @@
+{
+  nixpkgs = fetchGit {
+    url = "https://github.com/nixos/nixpkgs-channels";
+    ref = "nixos-19.09";
+    rev = "ea553d8c67c6a718448da50826ff5b6916dc9c59";
+  };
+
+  mcd-cli = fetchGit {
+    url = https://github.com/makerdao/mcd-cli.git;
+    rev = "86842b49defa53301ac0019f7d5994859bb3e1e9";
+  };
+
+  sethret = fetchGit {
+    url = https://github.com/icetan/sethret.git;
+    rev = "ef77915e2881011603491275f36b44bf2478b408";
+  };
+
+  dapp2nix = fetchGit {
+    url = "https://github.com/icetan/dapp2nix";
+    ref = "v2.1.7";
+    rev = "5d433e6d5d8b89da808a51a3c8a0559893efbaf5";
+  };
+
+  abi-to-dhall = fetchGit {
+    url = "https://github.com/icetan/abi-to-dhall";
+    rev = "c7e8518c6c8ef3ab6e6b0cf7c141dc8956dfaae3";
+    ref = "v1.0.1";
+  };
+}

--- a/srcs.nix
+++ b/srcs.nix
@@ -5,11 +5,6 @@
     rev = "ea553d8c67c6a718448da50826ff5b6916dc9c59";
   };
 
-  mcd-cli = fetchGit {
-    url = https://github.com/makerdao/mcd-cli.git;
-    rev = "86842b49defa53301ac0019f7d5994859bb3e1e9";
-  };
-
   sethret = fetchGit {
     url = https://github.com/icetan/sethret.git;
     rev = "ef77915e2881011603491275f36b44bf2478b408";


### PR DESCRIPTION
Instead of adding both the `dapptools` and `maker` overlays on top of `nixpkgs` now only `./overlays.nix` is added to a version of `nixpkgs` (specified in `./srcs.nix`) and `dapptools` is added as `dappPkgs` with its own version of `nixpkgs`.